### PR TITLE
support extension filename: .mjs

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -15,6 +15,7 @@ export function compile(code: string, filepath: string): IMark[] | void {
   switch (path.extname(filepath)) {
     case ".js":
     case ".jsx":
+    case ".mjs":
       return JavascriptCompiler(code, filepath);
     case ".ts":
     case ".tsx":


### PR DESCRIPTION
Some projects are using `.mjs` extension.
And sometimes, I also use `.mjs` extension filename to emphasize this file is using ES6 module.

I hope this feature could be implemented.